### PR TITLE
修复条件筛选"签到元数据"和"签到记录"的接口

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -541,14 +541,14 @@ public class SysCourseSigninRecord extends BaseEntity {
     参数:       无
     返回值:     表格数据对象
     权限:       system:signinRecord:myPending
-    ```
+    ``` 
 
 3. 查看某个签到的结果
     ```
-    URL:        GET ~/system/signinRecord/list/{signinId}
-    参数:       Long signinId
-    参数方式:   路径参数
-    返回值:     成功与否
+    URL:        GET ~/system/signinRecord/list/
+    参数:       SysCourseSigninRecord
+    参数方式:   路径参数自动绑定到类对象
+    返回值:     List<SysCourseSigninRecord> 签到记录列表
     权限:       system:signinRecord:list
     ```
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -440,12 +440,12 @@ public class SysCourseSignin extends BaseEntity{
     private String delFlag;
 }
 ```
-1. 根据班级Id查询所有的签到
+1. 条件筛选签到活动
     - admin
     ```
-    URL:        GET ~/system/signin/list/{signinId}
-    参数:       Long signinId
-    参数方式:   路径参数
+    URL:        GET ~/system/signin/list
+    参数:       SysCourseSignin
+    参数方式:   路径参数自动绑定到类对象
     返回值:     List<SysCourseSignin> 签到元数据列表
     权限:       system:signin:list
     ```

--- a/ruoyi-admin/src/main/java/com/ruoyi/web/controller/system/SysCourseSigninController.java
+++ b/ruoyi-admin/src/main/java/com/ruoyi/web/controller/system/SysCourseSigninController.java
@@ -37,7 +37,7 @@ public class SysCourseSigninController extends BaseController
     /**
      * 查询课程签到列表（admin）
      */
-    @GetMapping("/list/{signinId}")
+    @GetMapping("/list")
     public TableDataInfo list(SysCourseSignin query)
     {
         startPage();
@@ -76,7 +76,7 @@ public class SysCourseSigninController extends BaseController
 
         int rows = signinService.insertCourseSignin(signin);
 
-        Long signinId = signin.getId();
+        Long signinId = signin.getSigninId();
         if (rows > 0 && signinId != null) {
             // 预生成签到记录
             recordService.generateSigninRecords(signin); // 里面用 signin.getId()

--- a/ruoyi-admin/src/main/java/com/ruoyi/web/controller/system/SysCourseSigninRecordController.java
+++ b/ruoyi-admin/src/main/java/com/ruoyi/web/controller/system/SysCourseSigninRecordController.java
@@ -47,14 +47,14 @@ public class SysCourseSigninRecordController extends BaseController {
         return getDataTable(list);
     }
 
-    /**
-     * 查询某个签到的结果（admin）
-     */
-    @GetMapping("/list/{signinId}")
-    public AjaxResult list(@PathVariable Long signinId) {
-        SysCourseSigninRecord query = new SysCourseSigninRecord();
-        query.setSigninId(signinId);
-
+    /** 
+     * 条件查询某个签到记录
+     * @param query 条件
+     * @return 成功与否
+    */
+    @GetMapping("/list")
+    public AjaxResult list(SysCourseSigninRecord query)
+    {
         List<SysCourseSigninRecord> list = recordService.selectSigninRecordList(query);
         return AjaxResult.success(list);
     }

--- a/ruoyi-system/src/main/java/com/ruoyi/system/domain/SysCourseSignin.java
+++ b/ruoyi-system/src/main/java/com/ruoyi/system/domain/SysCourseSignin.java
@@ -11,7 +11,7 @@ import com.ruoyi.common.core.domain.BaseEntity;
 
 public class SysCourseSignin extends BaseEntity{
     /** 签到的ID **/
-    private Long id;
+    private Long signinId;
 
     /** 课程ID **/
     @Excel(name = "课程ID")
@@ -45,12 +45,12 @@ public class SysCourseSignin extends BaseEntity{
     private String delFlag;
 
     // getter/setter
-    public Long getId() {
-      return id;
+    public Long getSigninId() {
+      return signinId;
     }
 
-    public void setId(Long id) {
-      this.id = id;
+    public void setSigninId(Long signinId) {
+      this.signinId = signinId;
     }
 
     public Long getCourseId() {

--- a/ruoyi-system/src/main/java/com/ruoyi/system/service/impl/SysCourseSigninRecordServiceImpl.java
+++ b/ruoyi-system/src/main/java/com/ruoyi/system/service/impl/SysCourseSigninRecordServiceImpl.java
@@ -87,7 +87,7 @@ public class SysCourseSigninRecordServiceImpl implements ISysCourseSigninRecordS
         List<SysCourseSigninRecord> records = new ArrayList<>();
         for (SysUser stu : students) {
             SysCourseSigninRecord r = new SysCourseSigninRecord();
-            r.setSigninId(signin.getId());
+            r.setSigninId(signin.getSigninId());
             r.setUserId(stu.getUserId());
             r.setCourseId(signin.getCourseId());
             r.setStatus("0"); // 未签到

--- a/ruoyi-system/src/main/resources/mapper/system/SysCourseSigninMapper.xml
+++ b/ruoyi-system/src/main/resources/mapper/system/SysCourseSigninMapper.xml
@@ -39,6 +39,9 @@
     <select id="selectCourseSigninList" resultMap="SysCourseSigninResult">
         <include refid="selectCourseSigninVo"/>
         WHERE cs.del_flag = '0'
+        <if test ="signinId != null and signinId != 0">
+            AND cs.signin_id = #{signinId}
+        </if>
         <if test="courseId != null and courseId != 0">
             AND cs.course_id = #{courseId}
         </if>

--- a/ruoyi-system/src/main/resources/mapper/system/SysCouseSigninRecordMapper.xml
+++ b/ruoyi-system/src/main/resources/mapper/system/SysCouseSigninRecordMapper.xml
@@ -50,6 +50,9 @@
         <if test="status != null and status != ''">
             AND sr.status = #{status}
         </if>
+        <if test="recordId != null and recordId != ''">
+            AND sr.record_id = #{recordId}
+        </if>
         ORDER BY sr.create_time DESC
     </select>
 


### PR DESCRIPTION
修复了了GET ~/system/signinRecord/list/和GET ~/system/signin/list, 现在可以正常的条件筛选了